### PR TITLE
Update config to ESLint v1.x compatible format

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
     // https://docs.npmjs.com/misc/coding-style#indentation
     indent: [2, 2,
       // This is implicit in the source code
-      {indentSwitchCase: true},
+      {SwitchCase: 1},
     ],
 
     // https://docs.npmjs.com/misc/coding-style#curly-braces


### PR DESCRIPTION
The `indent` rule syntax has changed slightly between ESLint 0.x and 1.x/2.x:

```
indent: [2, 2, {indentSwitchCase: true}]
```

is no longer valid and needs to be replaced with

```
indent: [2, 2, {SwitchCase: 1}]
```
